### PR TITLE
feat: Add SettingsScreen

### DIFF
--- a/src/navigation/MainTabs.tsx
+++ b/src/navigation/MainTabs.tsx
@@ -3,6 +3,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import DashboardScreen from '../screens/Main/DashboardScreen';
 import NewBidScreen from '../screens/Main/NewBidScreen';
 import AdminScreen from '../screens/Main/AdminScreen';
+import SettingsScreen from '../screens/Main/SettingsScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -12,6 +13,7 @@ const MainTabs = () => {
       <Tab.Screen name="Dashboard" component={DashboardScreen} />
       <Tab.Screen name="New Bid" component={NewBidScreen} />
       <Tab.Screen name="Admin" component={AdminScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
     </Tab.Navigator>
   );
 };

--- a/src/screens/Main/SettingsScreen.tsx
+++ b/src/screens/Main/SettingsScreen.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from 'react';
+import { ScrollView, View, StyleSheet } from 'react-native';
+import { Button, TextInput, Text } from 'react-native-paper';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../../config/firebaseConfig';
+import { AppSettings } from '../../types/interfaces';
+
+const SettingsScreen = () => {
+  const [settings, setSettings] = useState<AppSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      const docRef = doc(db, 'settings', 'globalConfig');
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        setSettings(docSnap.data() as AppSettings);
+      }
+      setLoading(false);
+    };
+
+    fetchSettings();
+  }, []);
+
+  const handleSave = async () => {
+    if (settings) {
+      const docRef = doc(db, 'settings', 'globalConfig');
+      const settingsToSave = Object.fromEntries(
+        Object.entries(settings).map(([key, value]) => [key, Number(value)])
+      );
+      await setDoc(docRef, settingsToSave, { merge: true });
+      alert('Settings saved successfully!');
+    }
+  };
+
+  const handleChange = (name: keyof AppSettings, value: string) => {
+    if (settings) {
+      setSettings({ ...settings, [name]: value });
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <Text>Loading...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container}>
+      {settings &&
+        Object.keys(settings).map((key) => (
+          <TextInput
+            key={key}
+            label={key.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase())}
+            value={String(settings[key as keyof AppSettings])}
+            onChangeText={(text) => handleChange(key as keyof AppSettings, text)}
+            keyboardType="numeric"
+            style={styles.input}
+          />
+        ))}
+      <Button mode="contained" onPress={handleSave} style={styles.button}>
+        Save
+      </Button>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  input: {
+    marginBottom: 16,
+  },
+  button: {
+    marginTop: 16,
+  },
+});
+
+export default SettingsScreen;


### PR DESCRIPTION
This commit introduces the SettingsScreen, which allows for the management of global application settings stored in Firestore.

The screen provides a user interface for viewing and editing all settings defined in the `AppSettings` interface. Changes are saved to the `settings/globalConfig` document in Firestore.

Key changes:
- Created `src/screens/Main/SettingsScreen.tsx` with the UI and logic for fetching and saving settings.
- Used `react-native-paper` for UI components.
- Added a new "Settings" tab to the main navigation in `src/navigation/MainTabs.tsx`.
- Installed the `react-native-paper` dependency.