### PR TITLE
feat: Implement CRUD interface for materials

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { ActivityIndicator, View, StyleSheet } from 'react-native';
 import AuthNavigator from '../src/navigation/AuthStack';
-import MainTabs from '../src/navigation/MainTabs';
+import MainStack from '../src/navigation/MainStack';
 import { AuthProvider, useAuth } from '../src/context/AuthContext';
 
 const RootNavigator = () => {
@@ -17,8 +17,8 @@ const RootNavigator = () => {
   }
 
   return (
-    <NavigationContainer>
-      {user ? <MainTabs /> : <AuthNavigator />}
+    <NavigationContainer independent={true}>
+      {user ? <MainStack /> : <AuthNavigator />}
     </NavigationContainer>
   );
 };

--- a/src/components/MaterialForm.tsx
+++ b/src/components/MaterialForm.tsx
@@ -1,0 +1,117 @@
+import React, { useState, useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import {
+  Modal,
+  Portal,
+  TextInput,
+  Button,
+  Card,
+  Title,
+} from 'react-native-paper';
+import { Material } from '../types/interfaces';
+import { addMaterial, updateMaterial } from '../services/materialService';
+
+interface MaterialFormProps {
+  visible: boolean;
+  onDismiss: () => void;
+  onSave: () => void;
+  material: Material | null;
+}
+
+const MaterialForm = ({
+  visible,
+  onDismiss,
+  onSave,
+  material,
+}: MaterialFormProps) => {
+  const [materialName, setMaterialName] = useState('');
+  const [defaultUnitCost, setDefaultUnitCost] = useState('');
+  const [defaultMarkupPercent, setDefaultMarkupPercent] = useState('');
+
+  useEffect(() => {
+    if (material) {
+      setMaterialName(material.materialName);
+      setDefaultUnitCost(material.defaultUnitCost.toString());
+      setDefaultMarkupPercent(material.defaultMarkupPercent.toString());
+    } else {
+      setMaterialName('');
+      setDefaultUnitCost('');
+      setDefaultMarkupPercent('');
+    }
+  }, [material]);
+
+  const handleSave = async () => {
+    const materialData = {
+      materialName,
+      defaultUnitCost: parseFloat(defaultUnitCost) || 0,
+      defaultMarkupPercent: parseFloat(defaultMarkupPercent) || 0,
+    };
+
+    try {
+      if (material) {
+        await updateMaterial(material.id, materialData);
+      } else {
+        await addMaterial(materialData);
+      }
+      onSave();
+    } catch (error) {
+      console.error('Error saving material:', error);
+    }
+  };
+
+  return (
+    <Portal>
+      <Modal
+        visible={visible}
+        onDismiss={onDismiss}
+        contentContainerStyle={styles.container}
+      >
+        <Card>
+          <Card.Content>
+            <Title>{material ? 'Edit Material' : 'Add Material'}</Title>
+            <TextInput
+              label="Material Name"
+              value={materialName}
+              onChangeText={setMaterialName}
+              style={styles.input}
+            />
+            <TextInput
+              label="Default Unit Cost"
+              value={defaultUnitCost}
+              onChangeText={setDefaultUnitCost}
+              keyboardType="numeric"
+              style={styles.input}
+            />
+            <TextInput
+              label="Default Markup Percent"
+              value={defaultMarkupPercent}
+              onChangeText={setDefaultMarkupPercent}
+              keyboardType="numeric"
+              style={styles.input}
+            />
+            <Button mode="contained" onPress={handleSave} style={styles.button}>
+              Save
+            </Button>
+            <Button onPress={onDismiss} style={styles.button}>
+              Cancel
+            </Button>
+          </Card.Content>
+        </Card>
+      </Modal>
+    </Portal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+  input: {
+    marginBottom: 10,
+  },
+  button: {
+    marginTop: 10,
+  },
+});
+
+export default MaterialForm;

--- a/src/navigation/MainStack.tsx
+++ b/src/navigation/MainStack.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import MainTabs from './MainTabs';
+import MaterialsScreen from '../screens/Main/MaterialsScreen';
+
+const Stack = createNativeStackNavigator();
+
+const MainStack = () => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="MainTabs"
+        component={MainTabs}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="Materials"
+        component={MaterialsScreen}
+        options={{ title: 'Manage Materials' }}
+      />
+    </Stack.Navigator>
+  );
+};
+
+export default MainStack;

--- a/src/screens/Main/AdminScreen.tsx
+++ b/src/screens/Main/AdminScreen.tsx
@@ -1,10 +1,21 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { List } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
 
 const AdminScreen = () => {
+  const navigation = useNavigation();
+
   return (
     <View style={styles.container}>
-      <Text>Admin Screen</Text>
+      <List.Section>
+        <List.Subheader>Management</List.Subheader>
+        <List.Item
+          title="Manage Materials"
+          left={() => <List.Icon icon="hammer-wrench" />}
+          onPress={() => navigation.navigate('Materials')}
+        />
+      </List.Section>
     </View>
   );
 };
@@ -12,8 +23,6 @@ const AdminScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 });
 

--- a/src/screens/Main/MaterialsScreen.tsx
+++ b/src/screens/Main/MaterialsScreen.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useCallback } from 'react';
+import { View, FlatList, StyleSheet } from 'react-native';
+import {
+  List,
+  Button,
+  IconButton,
+  Divider,
+  Text,
+} from 'react-native-paper';
+import { useFocusEffect } from '@react-navigation/native';
+import { getMaterials, deleteMaterial } from '../../services/materialService';
+import { Material } from '../../types/interfaces';
+import MaterialForm from '../../components/MaterialForm';
+
+const MaterialsScreen = ({ navigation }) => {
+  const [materials, setMaterials] = useState<Material[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selectedMaterial, setSelectedMaterial] = useState<Material | null>(
+    null
+  );
+
+  const fetchMaterials = async () => {
+    setLoading(true);
+    try {
+      const materialsData = await getMaterials();
+      setMaterials(materialsData);
+    } catch (error) {
+      console.error('Error fetching materials:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchMaterials();
+    }, [])
+  );
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteMaterial(id);
+      fetchMaterials(); // Refresh list after deleting
+    } catch (error) {
+      console.error('Error deleting material:', error);
+    }
+  };
+
+  const handleSave = () => {
+    setModalVisible(false);
+    fetchMaterials();
+  };
+
+  const renderItem = ({ item }: { item: Material }) => (
+    <>
+      <List.Item
+        title={item.materialName}
+        description={`Cost: $${item.defaultUnitCost.toFixed(
+          2
+        )} | Markup: ${item.defaultMarkupPercent}%`}
+        right={() => (
+          <View style={{ flexDirection: 'row' }}>
+            <IconButton
+              icon="pencil"
+              onPress={() => {
+                setSelectedMaterial(item);
+                setModalVisible(true);
+              }}
+            />
+            <IconButton icon="delete" onPress={() => handleDelete(item.id)} />
+          </View>
+        )}
+      />
+      <Divider />
+    </>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <Text>Loading materials...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={materials}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id}
+      />
+      <Button
+        mode="contained"
+        onPress={() => {
+          setSelectedMaterial(null);
+          setModalVisible(true);
+        }}
+        style={styles.addButton}
+      >
+        Add Material
+      </Button>
+      <MaterialForm
+        visible={modalVisible}
+        onDismiss={() => setModalVisible(false)}
+        onSave={handleSave}
+        material={selectedMaterial}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  addButton: {
+    margin: 16,
+  },
+});
+
+export default MaterialsScreen;

--- a/src/services/materialService.ts
+++ b/src/services/materialService.ts
@@ -1,0 +1,39 @@
+import {
+  collection,
+  getDocs,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+} from 'firebase/firestore';
+import { db } from '../config/firebaseConfig';
+import { Material } from '../types/interfaces';
+
+const materialsCollection = collection(db, 'materials');
+
+export const getMaterials = async (): Promise<Material[]> => {
+  const snapshot = await getDocs(materialsCollection);
+  return snapshot.docs.map(
+    (doc) => ({ id: doc.id, ...doc.data() } as Material)
+  );
+};
+
+export const addMaterial = async (
+  material: Omit<Material, 'id'>
+): Promise<string> => {
+  const docRef = await addDoc(materialsCollection, material);
+  return docRef.id;
+};
+
+export const updateMaterial = async (
+  id: string,
+  material: Partial<Material>
+): Promise<void> => {
+  const materialDoc = doc(db, 'materials', id);
+  await updateDoc(materialDoc, material);
+};
+
+export const deleteMaterial = async (id: string): Promise<void> => {
+  const materialDoc = doc(db, 'materials', id);
+  await deleteDoc(materialDoc);
+};


### PR DESCRIPTION
This commit introduces a complete CRUD (Create, Read, Update, Delete) interface for managing materials in the Firestore collection.

The new functionality includes:
- A `MaterialsScreen` that lists all materials from Firestore.
- A `MaterialForm` modal for adding and editing materials.
- A `materialService` to handle all Firestore operations related to materials.
- Navigation from the `AdminScreen` to the new `MaterialsScreen`.

The implementation uses React Native Paper for UI components.